### PR TITLE
Принять участие в событии

### DIFF
--- a/src/Application/Bundle/DefaultBundle/Resources/views/Event/slider.html.twig
+++ b/src/Application/Bundle/DefaultBundle/Resources/views/Event/slider.html.twig
@@ -13,9 +13,9 @@
 
             <p>{{ event.description }}</p>
 
-            {% if event.receivePayments %}
+            {#{% if event.receivePayments %}#}
                 <a class="register" href="{{ path('event_takePart', {'event_slug': event.slug }) }}">Принять участие</a>
-            {% endif %}
+            {#{% endif %}#}
             <a class="know-more" href="{{ path('event_show', {'event_slug': event.slug }) }}">Узнать больше</a>
         </div>
     </div>


### PR DESCRIPTION
Закомментировал условие по которому эта ссылка показывалась только, если для события была разрешена продажа билетов.
Собственно теперь, если продажа отключена, то можно присоедениться к событию. В личном кабинете это событие появится, но для него не будет видна кнопка "Оплатить", но будет писаться "Участие не оплачено"
