### PR TITLE
Refactoring fixtures

### DIFF
--- a/src/Application/Bundle/UserBundle/DataFixtures/ORM/LoadUserData.php
+++ b/src/Application/Bundle/UserBundle/DataFixtures/ORM/LoadUserData.php
@@ -2,16 +2,15 @@
 
 namespace Application\Bundle\UserBundle\DataFixtures\ORM;
 
-use Doctrine\Common\DataFixtures\AbstractFixture;
-use Doctrine\Common\DataFixtures\OrderedFixtureInterface;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Common\DataFixtures\AbstractFixture,
+    Doctrine\Common\Persistence\ObjectManager;
 
 use Application\Bundle\UserBundle\Entity\User;
 
 /**
- * Users fixtures
+ * LoadUserData class
  */
-class LoadUserData extends AbstractFixture implements OrderedFixtureInterface
+class LoadUserData extends AbstractFixture
 {
     /**
      * Create and load user fixtures to database
@@ -32,7 +31,6 @@ class LoadUserData extends AbstractFixture implements OrderedFixtureInterface
         $userAdmin->setExpired(false);
         $userAdmin->setLocked(false);
         $manager->persist($userAdmin);
-        $manager->flush();
         $this->addReference('user-admin', $userAdmin);
 
         $userDefault = new User();
@@ -49,17 +47,8 @@ class LoadUserData extends AbstractFixture implements OrderedFixtureInterface
         $userDefault->setExpired(false);
         $userDefault->setLocked(false);
         $manager->persist($userDefault);
-        $manager->flush();
         $this->addReference('user-default', $userDefault);
-    }
 
-    /**
-     * Get the number for sorting fixture
-     *
-     * @return integer
-     */
-    public function getOrder()
-    {
-        return 1; // the order in which fixtures will be loaded
+        $manager->flush();
     }
 }

--- a/src/Stfalcon/Bundle/EventBundle/DataFixtures/ORM/LoadEventData.php
+++ b/src/Stfalcon/Bundle/EventBundle/DataFixtures/ORM/LoadEventData.php
@@ -3,8 +3,8 @@
 namespace Stfalcon\Bundle\EventBundle\DataFixtures\ORM;
 
 use Doctrine\Common\DataFixtures\AbstractFixture,
-    Doctrine\Common\DataFixtures\OrderedFixtureInterface,
     Doctrine\Common\Persistence\ObjectManager;
+
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 
 use Stfalcon\Bundle\EventBundle\Entity\Event;
@@ -12,7 +12,7 @@ use Stfalcon\Bundle\EventBundle\Entity\Event;
 /**
  * LoadEventData Class
  */
-class LoadEventData extends AbstractFixture implements OrderedFixtureInterface
+class LoadEventData extends AbstractFixture
 {
     /**
      * @param \Doctrine\Common\Persistence\ObjectManager $manager
@@ -30,11 +30,8 @@ class LoadEventData extends AbstractFixture implements OrderedFixtureInterface
         $event->setDate(new \DateTime("2012-04-19", new \DateTimeZone('Europe/Kiev')));
         $event->setReceivePayments(true);
         $event->setCost(100);
-
         $manager->persist($event);
         $this->addReference('event-zfday', $event);
-
-        unset($event);
 
         $event = new Event();
         $event->setName('PHP Frameworks Day');
@@ -46,11 +43,8 @@ class LoadEventData extends AbstractFixture implements OrderedFixtureInterface
         $event->setAbout("Описание события");
         $event->setDate(new \DateTime("2012-11-18", new \DateTimeZone('Europe/Kiev')));
         $event->setCost(100);
-
         $manager->persist($event);
         $this->addReference('event-phpday', $event);
-
-        unset($event);
 
         $event = new Event();
         $event->setName('Not Active Frameworks Day');
@@ -63,7 +57,6 @@ class LoadEventData extends AbstractFixture implements OrderedFixtureInterface
         $event->setActive(false);
         $event->setDate(new \DateTime("2012-12-12", new \DateTimeZone('Europe/Kiev')));
         $event->setCost(100);
-
         $manager->persist($event);
         $this->addReference('event-not-active', $event);
 
@@ -74,6 +67,8 @@ class LoadEventData extends AbstractFixture implements OrderedFixtureInterface
      * Generate UploadedFile object from local file. For VichUploader
      *
      * @param string $filename
+     *
+     * @return UploadedFile
      */
     private function _generateUploadedFile($filename)
     {
@@ -84,13 +79,5 @@ class LoadEventData extends AbstractFixture implements OrderedFixtureInterface
         return new UploadedFile($tmpFile,
             $filename, null, null, null, true
         );
-    }
-
-    /**
-     * @return int
-     */
-    public function getOrder()
-    {
-        return 1; // the order in which fixtures will be loaded
     }
 }

--- a/src/Stfalcon/Bundle/EventBundle/DataFixtures/ORM/LoadNewsData.php
+++ b/src/Stfalcon/Bundle/EventBundle/DataFixtures/ORM/LoadNewsData.php
@@ -3,13 +3,31 @@
 namespace Stfalcon\Bundle\EventBundle\DataFixtures\ORM;
 
 use Doctrine\Common\DataFixtures\AbstractFixture,
-    Doctrine\Common\DataFixtures\OrderedFixtureInterface,
+    Doctrine\Common\DataFixtures\DependentFixtureInterface,
     Doctrine\Common\Persistence\ObjectManager;
 
 use Stfalcon\Bundle\EventBundle\Entity\News;
 
-class LoadNewsData extends AbstractFixture implements OrderedFixtureInterface
+/**
+ * LoadNewsData Class
+ */
+class LoadNewsData extends AbstractFixture implements DependentFixtureInterface
 {
+    /**
+     * Return fixture classes fixture is dependent on
+     *
+     * @return array
+     */
+    public function getDependencies()
+    {
+        return array(
+            'Stfalcon\Bundle\EventBundle\DataFixtures\ORM\LoadEventData',
+        );
+    }
+
+    /**
+     * @param \Doctrine\Common\Persistence\ObjectManager $manager
+     */
     public function load(ObjectManager $manager)
     {
         $news = new News();
@@ -22,10 +40,5 @@ class LoadNewsData extends AbstractFixture implements OrderedFixtureInterface
 
         $manager->persist($news);
         $manager->flush();
-    }
-
-    public function getOrder()
-    {
-        return 2; // the order in which fixtures will be loaded
     }
 }

--- a/src/Stfalcon/Bundle/EventBundle/DataFixtures/ORM/LoadPagesData.php
+++ b/src/Stfalcon/Bundle/EventBundle/DataFixtures/ORM/LoadPagesData.php
@@ -3,13 +3,31 @@
 namespace Stfalcon\Bundle\EventBundle\DataFixtures\ORM;
 
 use Doctrine\Common\DataFixtures\AbstractFixture,
-    Doctrine\Common\DataFixtures\OrderedFixtureInterface,
+    Doctrine\Common\DataFixtures\DependentFixtureInterface,
     Doctrine\Common\Persistence\ObjectManager;
 
 use Stfalcon\Bundle\EventBundle\Entity\Page;
 
-class LoadPagesData extends AbstractFixture implements OrderedFixtureInterface
+/**
+ * LoadPagesData Class
+ */
+class LoadPagesData extends AbstractFixture implements DependentFixtureInterface
 {
+    /**
+     * Return fixture classes fixture is dependent on
+     *
+     * @return array
+     */
+    public function getDependencies()
+    {
+        return array(
+            'Stfalcon\Bundle\EventBundle\DataFixtures\ORM\LoadEventData',
+        );
+    }
+
+    /**
+     * @param \Doctrine\Common\Persistence\ObjectManager $manager
+     */
     public function load(ObjectManager $manager)
     {
         $page = new Page();
@@ -21,10 +39,5 @@ class LoadPagesData extends AbstractFixture implements OrderedFixtureInterface
 
         $manager->persist($page);
         $manager->flush();
-    }
-
-    public function getOrder()
-    {
-        return 4; // the order in which fixtures will be loaded
     }
 }

--- a/src/Stfalcon/Bundle/EventBundle/DataFixtures/ORM/LoadReviewData.php
+++ b/src/Stfalcon/Bundle/EventBundle/DataFixtures/ORM/LoadReviewData.php
@@ -3,7 +3,7 @@
 namespace Stfalcon\Bundle\EventBundle\DataFixtures\ORM;
 
 use Doctrine\Common\DataFixtures\AbstractFixture,
-    Doctrine\Common\DataFixtures\OrderedFixtureInterface,
+    Doctrine\Common\DataFixtures\DependentFixtureInterface,
     Doctrine\Common\Persistence\ObjectManager;
 
 use Stfalcon\Bundle\EventBundle\Entity\Review;
@@ -11,63 +11,66 @@ use Stfalcon\Bundle\EventBundle\Entity\Review;
 /**
  * LoadReviewData Class
  */
-class LoadReviewData extends AbstractFixture implements OrderedFixtureInterface
+class LoadReviewData extends AbstractFixture implements DependentFixtureInterface
 {
+    /**
+     * Return fixture classes fixture is dependent on
+     *
+     * @return array
+     */
+    public function getDependencies()
+    {
+        return array(
+            'Stfalcon\Bundle\EventBundle\DataFixtures\ORM\LoadEventData',
+            'Stfalcon\Bundle\EventBundle\DataFixtures\ORM\LoadSpeakerData',
+        );
+    }
+
     /**
      * @param \Doctrine\Common\Persistence\ObjectManager $manager
      */
     public function load(ObjectManager $manager)
     {
+        // Get references for event fixtures
+        $eventZFDay  = $manager->merge($this->getReference('event-zfday'));
+        $eventPHPDay = $manager->merge($this->getReference('event-phpday'));
+
+        // Get references for speaker fixtures
+        $rabievskiy = $manager->merge($this->getReference('speaker-rabievskiy'));
+        $shkodyak   = $manager->merge($this->getReference('speaker-shkodyak'));
+
         $review = new Review();
         $review->setTitle('ZF first steps');
         $review->setSlug('zf-first-steps');
         $review->setText('Zend Framework 2.0 is amazing');
-        $review->setEvent($manager->merge($this->getReference('event-zfday')));
-        $review->setSpeaker(array($manager->merge($this->getReference('speaker-rabievskiy'))));
-
+        $review->setEvent($eventZFDay);
+        $review->setSpeaker(array($rabievskiy));
         $manager->persist($review);
-
-        unset($review);
 
         $review = new Review();
         $review->setTitle('Symfony 2.1 first steps');
         $review->setSlug('symfony-2.1-first-steps');
         $review->setText('Symfony 2.1 is amazing');
-        $review->setEvent($manager->merge($this->getReference('event-phpday')));
-        $review->setSpeaker(array($manager->merge($this->getReference('speaker-rabievskiy'))));
-
+        $review->setEvent($eventPHPDay);
+        $review->setSpeaker(array($rabievskiy));
         $manager->persist($review);
-
-        unset($review);
 
         $review = new Review();
         $review->setTitle('Simple API via Zend Framework');
         $review->setSlug('simple-api-via-zend-framework');
         $review->setText('How to do simple API via Zend Framework');
-        $review->setEvent($manager->merge($this->getReference('event-zfday')));
-        $review->setSpeaker(array($manager->merge($this->getReference('speaker-shkodyak'))));
-
+        $review->setEvent($eventZFDay);
+        $review->setSpeaker(array($shkodyak));
         $manager->persist($review);
-
-        unset($review);
 
         $review = new Review();
         $review->setTitle('Symfony Forever');
         $review->setSlug('symfony-forever');
         $review->setText('Why we using and will use Symfony');
-        $review->setEvent($manager->merge($this->getReference('event-phpday')));
-        $review->setSpeaker(array($manager->merge($this->getReference('speaker-shkodyak'))));
-
+        $review->setEvent($eventPHPDay);
+        $review->setSpeaker(array($shkodyak));
         $manager->persist($review);
 
         $manager->flush();
-    }
-
-    /**
-     * @return int
-     */
-    public function getOrder()
-    {
-        return 6; // the order in which fixtures will be loaded
     }
 }

--- a/src/Stfalcon/Bundle/EventBundle/DataFixtures/ORM/LoadSpeakerData.php
+++ b/src/Stfalcon/Bundle/EventBundle/DataFixtures/ORM/LoadSpeakerData.php
@@ -3,22 +3,38 @@
 namespace Stfalcon\Bundle\EventBundle\DataFixtures\ORM;
 
 use Doctrine\Common\DataFixtures\AbstractFixture,
-    Doctrine\Common\DataFixtures\OrderedFixtureInterface,
+    Doctrine\Common\DataFixtures\DependentFixtureInterface,
     Doctrine\Common\Persistence\ObjectManager;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 
 use Stfalcon\Bundle\EventBundle\Entity\Speaker;
 
 /**
- * LoadSpeakersData Class
+ * LoadSpeakerData Class
  */
-class LoadSpeakersData extends AbstractFixture implements OrderedFixtureInterface
+class LoadSpeakerData extends AbstractFixture implements DependentFixtureInterface
 {
+    /**
+     * Return fixture classes fixture is dependent on
+     *
+     * @return array
+     */
+    public function getDependencies()
+    {
+        return array(
+            'Stfalcon\Bundle\EventBundle\DataFixtures\ORM\LoadEventData',
+        );
+    }
+
     /**
      * @param \Doctrine\Common\Persistence\ObjectManager $manager
      */
     public function load(ObjectManager $manager)
     {
+        // Get references for event fixtures
+        $eventZFDay  = $manager->merge($this->getReference('event-zfday'));
+        $eventPHPDay = $manager->merge($this->getReference('event-phpday'));
+
         $speaker = new Speaker();
         $speaker->setName('Андрей Шкодяк');
         $speaker->setEmail('a_s@test.com');
@@ -26,17 +42,9 @@ class LoadSpeakersData extends AbstractFixture implements OrderedFixtureInterfac
         $speaker->setAbout('About Andrew');
         $speaker->setSlug('andrew-shkodyak');
         $speaker->setFile($this->_generateUploadedFile('andrew.png'));
-        $speaker->setEvents(
-            array(
-                 $manager->merge($this->getReference('event-zfday')),
-                 $manager->merge($this->getReference('event-phpday')),
-            )
-        );
-
+        $speaker->setEvents(array($eventZFDay, $eventPHPDay));
         $manager->persist($speaker);
         $this->addReference('speaker-shkodyak', $speaker);
-
-        unset($speaker);
 
         $speaker = new Speaker();
         $speaker->setName('Валерий Рабиевский');
@@ -45,13 +53,7 @@ class LoadSpeakersData extends AbstractFixture implements OrderedFixtureInterfac
         $speaker->setAbout('About Valeriy');
         $speaker->setSlug('valeriy-rabievskiy');
         $speaker->setFile($this->_generateUploadedFile('valeriy.png'));
-        $speaker->setEvents(
-            array(
-                 $manager->merge($this->getReference('event-zfday')),
-                 $manager->merge($this->getReference('event-phpday')),
-            )
-        );
-
+        $speaker->setEvents(array($eventZFDay, $eventPHPDay));
         $manager->persist($speaker);
         $this->addReference('speaker-rabievskiy', $speaker);
 
@@ -62,6 +64,8 @@ class LoadSpeakersData extends AbstractFixture implements OrderedFixtureInterfac
      * Generate UploadedFile object from local file. For VichUploader
      *
      * @param string $filename
+     *
+     * @return UploadedFile
      */
     private function _generateUploadedFile($filename)
     {
@@ -72,13 +76,5 @@ class LoadSpeakersData extends AbstractFixture implements OrderedFixtureInterfac
         return new UploadedFile($tmpFile,
             $filename, null, null, null, true
         );
-    }
-
-    /**
-     * @return int
-     */
-    public function getOrder()
-    {
-        return 5; // the order in which fixtures will be loaded
     }
 }

--- a/src/Stfalcon/Bundle/EventBundle/DataFixtures/ORM/LoadTicketData.php
+++ b/src/Stfalcon/Bundle/EventBundle/DataFixtures/ORM/LoadTicketData.php
@@ -3,57 +3,52 @@
 namespace Stfalcon\Bundle\EventBundle\DataFixtures\ORM;
 
 use Doctrine\Common\DataFixtures\AbstractFixture,
-Doctrine\Common\DataFixtures\OrderedFixtureInterface,
-Doctrine\Common\Persistence\ObjectManager;
+    Doctrine\Common\DataFixtures\DependentFixtureInterface,
+    Doctrine\Common\Persistence\ObjectManager;
 
 use Stfalcon\Bundle\EventBundle\Entity\Ticket;
 
 /**
  * LoadTicketData Class
  */
-class LoadTicketData extends AbstractFixture implements OrderedFixtureInterface
+class LoadTicketData extends AbstractFixture implements DependentFixtureInterface
 {
+    /**
+     * Return fixture classes fixture is dependent on
+     *
+     * @return array
+     */
+    public function getDependencies()
+    {
+        return array(
+            'Application\Bundle\UserBundle\DataFixtures\ORM\LoadUserData',
+            'Stfalcon\Bundle\EventBundle\DataFixtures\ORM\LoadEventData',
+        );
+    }
+
     /**
      * @param \Doctrine\Common\Persistence\ObjectManager $manager
      */
     public function load(ObjectManager $manager)
     {
-        $ticket = new Ticket(
-            $manager->merge($this->getReference('event-zfday')),
-            $manager->merge($this->getReference('user-default')));
-        $ticket->setPayment($manager->merge($this->getReference('payment')));
+        $userDefault = $manager->merge($this->getReference('user-default'));
 
+        // Ticket 1
+        $ticket = new Ticket($manager->merge($this->getReference('event-zfday')), $userDefault);
+        $ticket->setPayment($manager->merge($this->getReference('payment')));
         $manager->persist($ticket);
         $this->addReference('ticket-1', $ticket);
 
-        unset($ticket);
-
-        $ticket = new Ticket(
-            $manager->merge($this->getReference('event-phpday')),
-            $manager->merge($this->getReference('user-default'))
-        );
-
+        // Ticket 2
+        $ticket = new Ticket($manager->merge($this->getReference('event-phpday')), $userDefault);
         $manager->persist($ticket);
         $this->addReference('ticket-2', $ticket);
 
-        unset($ticket);
-
-        $ticket = new Ticket(
-            $manager->merge($this->getReference('event-not-active')),
-            $manager->merge($this->getReference('user-default'))
-        );
-
+        // Ticket 3
+        $ticket = new Ticket($manager->merge($this->getReference('event-not-active')), $userDefault);
         $manager->persist($ticket);
         $this->addReference('ticket-3', $ticket);
 
         $manager->flush();
-    }
-
-    /**
-     * @return int
-     */
-    public function getOrder()
-    {
-        return 3; // the order in which fixtures will be loaded
     }
 }

--- a/src/Stfalcon/Bundle/EventBundle/Features/Context/FeatureContext.php
+++ b/src/Stfalcon/Bundle/EventBundle/Features/Context/FeatureContext.php
@@ -36,17 +36,17 @@ class FeatureContext extends MinkContext implements KernelAwareInterface
      */
     public function beforeScen()
     {
-
         $loader = new Loader();
         $loader->addFixture(new \Stfalcon\Bundle\EventBundle\DataFixtures\ORM\LoadEventData());
         $loader->addFixture(new \Stfalcon\Bundle\EventBundle\DataFixtures\ORM\LoadNewsData());
         $loader->addFixture(new \Stfalcon\Bundle\EventBundle\DataFixtures\ORM\LoadPagesData());
-        $loader->addFixture(new \Stfalcon\Bundle\EventBundle\DataFixtures\ORM\LoadSpeakersData());
+        $loader->addFixture(new \Stfalcon\Bundle\EventBundle\DataFixtures\ORM\LoadSpeakerData());
         $loader->addFixture(new \Stfalcon\Bundle\EventBundle\DataFixtures\ORM\LoadReviewData());
         $loader->addFixture(new \Stfalcon\Bundle\SponsorBundle\DataFixtures\ORM\LoadSponsorData());
         $loader->addFixture(new \Application\Bundle\UserBundle\DataFixtures\ORM\LoadUserData());
         $loader->addFixture(new \Stfalcon\Bundle\PaymentBundle\DataFixtures\ORM\LoadPaymentData());
         $loader->addFixture(new \Stfalcon\Bundle\EventBundle\DataFixtures\ORM\LoadTicketData());
+
         /** @var $em \Doctrine\ORM\EntityManager */
         $em = $this->kernel->getContainer()->get('doctrine.orm.entity_manager');
 
@@ -57,13 +57,15 @@ class FeatureContext extends MinkContext implements KernelAwareInterface
     }
 
     /**
+     * @param string $mail E-mail Ticket owner
+     *
      * @Given /^я оплатил билет для "([^"]*)"$/
      */
     public function iPayTicket($mail)
     {
         $em = $this->kernel->getContainer()->get('doctrine')->getEntityManager();
-        $user = $em->getRepository('ApplicationUserBundle:User')->findOneBy(array('username' => $mail));
-        $ticket = $em->getRepository('StfalconEventBundle:Ticket')->findOneBy(array('user' => $user->getId()));
+        $user    = $em->getRepository('ApplicationUserBundle:User')->findOneBy(array('username' => $mail));
+        $ticket  = $em->getRepository('StfalconEventBundle:Ticket')->findOneBy(array('user' => $user->getId()));
         $payment = $em->getRepository('StfalconPaymentBundle:Payment')->findOneBy(array('user' => $user->getId()));
         $payment->setStatus('paid');
         $ticket->setPayment($payment);
@@ -73,13 +75,15 @@ class FeatureContext extends MinkContext implements KernelAwareInterface
     }
 
     /**
+     * @param string $mail E-mail Ticket owner
+     *
      * @Given /^я не оплатил билет для "([^"]*)"$/
      */
     public function iDontPayTicket($mail)
     {
         $em = $this->kernel->getContainer()->get('doctrine')->getEntityManager();
-        $user = $em->getRepository('ApplicationUserBundle:User')->findOneBy(array('username' => $mail));
-        $ticket = $em->getRepository('StfalconEventBundle:Ticket')->findOneBy(array('user' => $user->getId()));
+        $user    = $em->getRepository('ApplicationUserBundle:User')->findOneBy(array('username' => $mail));
+        $ticket  = $em->getRepository('StfalconEventBundle:Ticket')->findOneBy(array('user' => $user->getId()));
         $payment = $em->getRepository('StfalconPaymentBundle:Payment')->findOneBy(array('user' => $user->getId()));
         $payment->setStatus('pending');
         $ticket->setPayment($payment);
@@ -89,6 +93,8 @@ class FeatureContext extends MinkContext implements KernelAwareInterface
     }
 
     /**
+     * @param string $mail E-mail Ticket owner
+     *
      * @Given /^я должен видеть полное имя для "([^"]*)"$/
      */
     public function iMustSeeFullname($mail)
@@ -99,6 +105,8 @@ class FeatureContext extends MinkContext implements KernelAwareInterface
     }
 
     /**
+     * @param string $mail E-mail Ticket owner
+     *
      * @Given /^я перехожу на страницу регистрации для "([^"]*)"$/
      */
     public function goToTicketRegistrationPage($mail)
@@ -107,6 +115,8 @@ class FeatureContext extends MinkContext implements KernelAwareInterface
     }
 
     /**
+     * @param string $mail E-mail Ticket owner
+     *
      * @Given /^я перехожу на страницу регистрации для "([^"]*)" с битым хешем$/
      */
     public function goToTicketRegistrationPageWithWrongHash($mail)
@@ -114,23 +124,25 @@ class FeatureContext extends MinkContext implements KernelAwareInterface
         $this->visit($this->getTicketUrl($mail) . 'fffuu');
     }
 
-    /*
+    /**
      * Generate URL for register ticket
-     * @param string $mail  E-mail Ticket owner
+     *
+     * @param string $mail E-mail Ticket owner
+     *
      * @return string
      */
     public function getTicketUrl($mail)
     {
         $em = $this->kernel->getContainer()->get('doctrine')->getEntityManager();
-        $user = $em->getRepository('ApplicationUserBundle:User')->findOneBy(array('username' => $mail));
+        $user   = $em->getRepository('ApplicationUserBundle:User')->findOneBy(array('username' => $mail));
         $ticket = $em->getRepository('StfalconEventBundle:Ticket')->findOneBy(array('user' => $user->getId()));
 
         return $this->kernel->getContainer()->get('router')->generate('event_ticket_check',
             array(
                 'ticket' => $ticket->getId(),
-                'hash' => $ticket->getHash()
-            ), true);
+                'hash'   => $ticket->getHash()
+            ),
+            true
+        );
     }
-
-
 }

--- a/src/Stfalcon/Bundle/PaymentBundle/DataFixtures/ORM/LoadPaymentData.php
+++ b/src/Stfalcon/Bundle/PaymentBundle/DataFixtures/ORM/LoadPaymentData.php
@@ -3,40 +3,41 @@
 namespace Stfalcon\Bundle\PaymentBundle\DataFixtures\ORM;
 
 use Doctrine\Common\DataFixtures\AbstractFixture,
-    Doctrine\Common\DataFixtures\OrderedFixtureInterface,
+    Doctrine\Common\DataFixtures\DependentFixtureInterface,
     Doctrine\Common\Persistence\ObjectManager;
 
 use Stfalcon\Bundle\PaymentBundle\Entity\Payment;
 
 /**
- * LoadTicketData Class
+ * LoadPaymentData Class
  */
-class LoadPaymentData extends AbstractFixture implements OrderedFixtureInterface
+class LoadPaymentData extends AbstractFixture implements DependentFixtureInterface
 {
+    /**
+     * Return fixture classes fixture is dependent on
+     *
+     * @return array
+     */
+    public function getDependencies()
+    {
+        return array(
+            'Application\Bundle\UserBundle\DataFixtures\ORM\LoadUserData',
+        );
+    }
+
     /**
      * @param \Doctrine\Common\Persistence\ObjectManager $manager
      */
     public function load(ObjectManager $manager)
     {
-        $payment = new Payment(
-            $manager->merge($this->getReference('user-default')),
-            100500
-        );
+        $userDefault = $manager->merge($this->getReference('user-default'));
+
+        $payment = new Payment($userDefault, 100500);
         $payment->setAmountWithoutDiscount(100500);
         $payment->setStatus(Payment::STATUS_PAID);
         $manager->persist($payment);
         $this->addReference('payment', $payment);
 
-        unset($payment);
-
         $manager->flush();
-    }
-
-    /**
-     * @return int
-     */
-    public function getOrder()
-    {
-        return 2; // the order in which fixtures will be loaded
     }
 }

--- a/src/Stfalcon/Bundle/SponsorBundle/DataFixtures/ORM/LoadCategoryData.php
+++ b/src/Stfalcon/Bundle/SponsorBundle/DataFixtures/ORM/LoadCategoryData.php
@@ -3,15 +3,14 @@
 namespace Stfalcon\Bundle\SponsorBundle\DataFixtures\ORM;
 
 use Doctrine\Common\DataFixtures\AbstractFixture,
-    Doctrine\Common\DataFixtures\OrderedFixtureInterface,
     Doctrine\Common\Persistence\ObjectManager;
 
 use Stfalcon\Bundle\SponsorBundle\Entity\Category;
 
 /**
- * Load Sponsor fixtures to database
+ * LoadCategoryData class
  */
-class LoadCategoryData extends AbstractFixture implements OrderedFixtureInterface
+class LoadCategoryData extends AbstractFixture
 {
     /**
      * @param \Doctrine\Common\Persistence\ObjectManager $manager
@@ -22,26 +21,14 @@ class LoadCategoryData extends AbstractFixture implements OrderedFixtureInterfac
         $golden->setName('Golden sponsor');
         $golden->setSortOrder(30);
         $manager->persist($golden);
-
-        $this->addReference('golden-sponsor',$golden);
+        $this->addReference('golden-sponsor', $golden);
 
         $silver = new Category();
         $silver->setName('Silver sponsor');
         $silver->setSortOrder(20);
         $manager->persist($silver);
-
-        $this->addReference('silver-sponsor',$silver);
+        $this->addReference('silver-sponsor', $silver);
 
         $manager->flush();
-    }
-
-    /**
-     * Return the order in which fixtures will be loaded
-     *
-     * @return integer The order in which fixtures will be loaded
-     */
-    public function getOrder()
-    {
-        return 2;
     }
 }

--- a/src/Stfalcon/Bundle/SponsorBundle/DataFixtures/ORM/LoadEventSponsorData.php
+++ b/src/Stfalcon/Bundle/SponsorBundle/DataFixtures/ORM/LoadEventSponsorData.php
@@ -3,52 +3,69 @@
 namespace Stfalcon\Bundle\SponsorBundle\DataFixtures\ORM;
 
 use Doctrine\Common\DataFixtures\AbstractFixture,
-    Doctrine\Common\DataFixtures\OrderedFixtureInterface,
+    Doctrine\Common\DataFixtures\DependentFixtureInterface,
     Doctrine\Common\Persistence\ObjectManager;
 
 use Stfalcon\Bundle\SponsorBundle\Entity\EventSponsor;
 
 /**
- * Load Sponsor fixtures to database
+ * LoadEventSponsorData class
  */
-class LoadEventSponsorData extends AbstractFixture implements OrderedFixtureInterface
+class LoadEventSponsorData extends AbstractFixture implements DependentFixtureInterface
 {
+    /**
+     * Return fixture classes fixture is dependent on
+     *
+     * @return array
+     */
+    public function getDependencies()
+    {
+        return array(
+            'Stfalcon\Bundle\SponsorBundle\DataFixtures\ORM\LoadCategoryData',
+            'Stfalcon\Bundle\SponsorBundle\DataFixtures\ORM\LoadSponsorData',
+            'Stfalcon\Bundle\EventBundle\DataFixtures\ORM\LoadEventData',
+        );
+    }
+
     /**
      * @param \Doctrine\Common\Persistence\ObjectManager $manager
      */
     public function load(ObjectManager $manager)
     {
+        // Get references for category fixtures
+        $goldenSponsor = $manager->merge($this->getReference('golden-sponsor'));
+        $silverSponsor = $manager->merge($this->getReference('silver-sponsor'));
+
+        // Get references for event fixtures
+        $eventZFDay  = $manager->merge($this->getReference('event-zfday'));
+        $eventPHPDay = $manager->merge($this->getReference('event-phpday'));
+
+        // Get references for sponsor fixtures
+        $sponsorODesk   = $manager->merge($this->getReference('sponsor-odesk'));
+        $sponsorMagento = $manager->merge($this->getReference('sponsor-magento'));
+        $sponsorEpochta = $manager->merge($this->getReference('sponsor-epochta'));
+
         // oDesk is Golden sponsor of PHP Frameworks Day 2012
-        $phpdayGoldenOdesk = new EventSponsor();
-        $phpdayGoldenOdesk->setCategory($manager->merge($this->getReference('golden-sponsor')));
-        $phpdayGoldenOdesk->setEvent($manager->merge($this->getReference('event-phpday')));
-        $phpdayGoldenOdesk->setSponsor($manager->merge($this->getReference('sponsor-odesk')));
-        $manager->persist($phpdayGoldenOdesk);
+        $eventSponsor = new EventSponsor();
+        $eventSponsor->setCategory($goldenSponsor);
+        $eventSponsor->setEvent($eventPHPDay);
+        $eventSponsor->setSponsor($sponsorODesk);
+        $manager->persist($eventSponsor);
 
         // Magento is Golden sponsor of Zend Framework Day 2011
-        $zfdayGoldenMagento = new EventSponsor();
-        $zfdayGoldenMagento->setCategory($manager->merge($this->getReference('golden-sponsor')));
-        $zfdayGoldenMagento->setEvent($manager->merge($this->getReference('event-zfday')));
-        $zfdayGoldenMagento->setSponsor($manager->merge($this->getReference('sponsor-magento')));
-        $manager->persist($zfdayGoldenMagento);
+        $eventSponsor = new EventSponsor();
+        $eventSponsor->setCategory($goldenSponsor);
+        $eventSponsor->setEvent($eventZFDay);
+        $eventSponsor->setSponsor($sponsorMagento);
+        $manager->persist($eventSponsor);
 
-        // ePochta is Silver sponsor of Zend Framework Day 2011
-        $zfdaySilverEpochta = new EventSponsor();
-        $zfdaySilverEpochta->setCategory($manager->merge($this->getReference('silver-sponsor')));
-        $zfdaySilverEpochta->setEvent($manager->merge($this->getReference('event-phpday')));
-        $zfdaySilverEpochta->setSponsor($manager->merge($this->getReference('sponsor-epochta')));
-        $manager->persist($zfdaySilverEpochta);
+        // ePochta is Silver sponsor of PHP Frameworks Day 2012
+        $eventSponsor = new EventSponsor();
+        $eventSponsor->setCategory($silverSponsor);
+        $eventSponsor->setEvent($eventPHPDay);
+        $eventSponsor->setSponsor($sponsorEpochta);
+        $manager->persist($eventSponsor);
 
         $manager->flush();
-    }
-
-    /**
-     * Return the order in which fixtures will be loaded
-     *
-     * @return integer The order in which fixtures will be loaded
-     */
-    public function getOrder()
-    {
-        return 4;
     }
 }

--- a/src/Stfalcon/Bundle/SponsorBundle/DataFixtures/ORM/LoadSponsorData.php
+++ b/src/Stfalcon/Bundle/SponsorBundle/DataFixtures/ORM/LoadSponsorData.php
@@ -3,7 +3,6 @@
 namespace Stfalcon\Bundle\SponsorBundle\DataFixtures\ORM;
 
 use Doctrine\Common\DataFixtures\AbstractFixture,
-    Doctrine\Common\DataFixtures\OrderedFixtureInterface,
     Doctrine\Common\Persistence\ObjectManager;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 
@@ -12,7 +11,7 @@ use Stfalcon\Bundle\SponsorBundle\Entity\Sponsor;
 /**
  * Load Sponsor fixtures to database
  */
-class LoadSponsorData extends AbstractFixture implements OrderedFixtureInterface
+class LoadSponsorData extends AbstractFixture
 {
     /**
      * @param \Doctrine\Common\Persistence\ObjectManager $manager
@@ -28,7 +27,6 @@ class LoadSponsorData extends AbstractFixture implements OrderedFixtureInterface
         $magento->setAbout('The Magento eCommerce platform serves more than 125,000 merchants worldwide and is supported by a global ecosystem of solution partners and third-party developers.');
         $magento->setSortOrder(10);
         $magento->setOnMain(true);
-
         $manager->persist($magento);
         $this->addReference('sponsor-magento', $magento);
 
@@ -41,7 +39,6 @@ class LoadSponsorData extends AbstractFixture implements OrderedFixtureInterface
         $odesk->setAbout('oDesk is a global marketplace that helps employers hire, manage, and pay remote freelancers or teams. It\'s free to post a job and hire from over 1 million top professionals.');
         $odesk->setSortOrder(20);
         $odesk->setOnMain(true);
-
         $manager->persist($odesk);
         $this->addReference('sponsor-odesk', $odesk);
 
@@ -53,7 +50,6 @@ class LoadSponsorData extends AbstractFixture implements OrderedFixtureInterface
         $epochta->setFile($this->_generateUploadedFile('epochta.png'));
         $epochta->setOnMain(false);
         $epochta->setSortOrder(15);
-
         $manager->persist($epochta);
         $this->addReference('sponsor-epochta', $epochta);
 
@@ -64,6 +60,8 @@ class LoadSponsorData extends AbstractFixture implements OrderedFixtureInterface
      * Generate UploadedFile object from local file. For VichUploader
      *
      * @param string $filename
+     *
+     * @return UploadedFile
      */
     private function _generateUploadedFile($filename)
     {
@@ -74,15 +72,5 @@ class LoadSponsorData extends AbstractFixture implements OrderedFixtureInterface
         return new UploadedFile($tmpFile,
             $filename, null, null, null, true
         );
-    }
-
-    /**
-     * Return the order in which fixtures will be loaded
-     *
-     * @return integer The order in which fixtures will be loaded
-     */
-    public function getOrder()
-    {
-        return 3;
     }
 }

--- a/src/Stfalcon/Bundle/SponsorBundle/Features/Context/FeatureContext.php
+++ b/src/Stfalcon/Bundle/SponsorBundle/Features/Context/FeatureContext.php
@@ -43,7 +43,7 @@ class FeatureContext extends MinkContext implements KernelAwareInterface
         $loader->addFixture(new \Stfalcon\Bundle\EventBundle\DataFixtures\ORM\LoadEventData());
         $loader->addFixture(new \Stfalcon\Bundle\EventBundle\DataFixtures\ORM\LoadNewsData());
         $loader->addFixture(new \Stfalcon\Bundle\EventBundle\DataFixtures\ORM\LoadPagesData());
-        $loader->addFixture(new \Stfalcon\Bundle\EventBundle\DataFixtures\ORM\LoadSpeakersData());
+        $loader->addFixture(new \Stfalcon\Bundle\EventBundle\DataFixtures\ORM\LoadSpeakerData());
         $loader->addFixture(new \Stfalcon\Bundle\EventBundle\DataFixtures\ORM\LoadReviewData());
         $loader->addFixture(new \Stfalcon\Bundle\PaymentBundle\DataFixtures\ORM\LoadPaymentData());
         $loader->addFixture(new \Stfalcon\Bundle\EventBundle\DataFixtures\ORM\LoadTicketData());
@@ -64,7 +64,7 @@ class FeatureContext extends MinkContext implements KernelAwareInterface
      * Check that some element contains image from some source
      *
      * @param string $src     Source of image
-     * @param string $element Selector enginen name
+     * @param string $element Selector engine name
      *
      * @Given /^я должен видеть картинку "([^"]*)" внутри элемента "([^"]*)"$/
      */
@@ -76,7 +76,8 @@ class FeatureContext extends MinkContext implements KernelAwareInterface
     /**
      * Check that some element not contains image from some source
      *
-     * @param string $src
+     * @param string $src     Source of image
+     * @param string $element Selector engine name
      *
      * @Given /^я не должен видеть картинку "([^"]*)" внутри элемента "([^"]*)"$/
      */
@@ -94,6 +95,7 @@ class FeatureContext extends MinkContext implements KernelAwareInterface
                 return true;
             }
         }
+
         return false;
     }
 


### PR DESCRIPTION
Зарефакторив фікстури, щоб вони юзали DependentFixtureInterface.
Всі фічі проходять.
Але є один нюанс. Зараз все ж таки потрібно писати всю пачку фікстур при їх загрузці в FeatureContext:

```
/**
     * @BeforeScenario
     */
    public function beforeScen()
    {
        $loader = new Loader();
        $loader->addFixture(new \Stfalcon\Bundle\EventBundle\DataFixtures\ORM\LoadEventData());
        $loader->addFixture(new \Stfalcon\Bundle\EventBundle\DataFixtures\ORM\LoadNewsData());
        $loader->addFixture(new \Stfalcon\Bundle\EventBundle\DataFixtures\ORM\LoadPagesData());
        $loader->addFixture(new \Stfalcon\Bundle\EventBundle\DataFixtures\ORM\LoadSpeakerData());
        $loader->addFixture(new \Stfalcon\Bundle\EventBundle\DataFixtures\ORM\LoadReviewData());
        $loader->addFixture(new \Stfalcon\Bundle\PaymentBundle\DataFixtures\ORM\LoadPaymentData());
        $loader->addFixture(new \Stfalcon\Bundle\EventBundle\DataFixtures\ORM\LoadTicketData());
        $loader->addFixture(new \Stfalcon\Bundle\SponsorBundle\DataFixtures\ORM\LoadSponsorData());
        $loader->addFixture(new \Stfalcon\Bundle\SponsorBundle\DataFixtures\ORM\LoadEventSponsorData());
        $loader->addFixture(new \Stfalcon\Bundle\SponsorBundle\DataFixtures\ORM\LoadCategoryData());
        $loader->addFixture(new \Application\Bundle\UserBundle\DataFixtures\ORM\LoadUserData());
```

Тут половину можна забрати, так як є залежності, але, щоб це зробити, потрібно дописати ще один метод, який розрулює загрузку залежних фікстур. Ось цей
https://github.com/liip/LiipFunctionalTestBundle/blob/master/Test/WebTestCase.php#L306

На МФБ це зроблено так: цей метод винесений в BaseFeatureContext, всі інші контексти наслідють базовий і мають доступ до цього методу.

Але ти колись казав, що не хочеш, щоб всі контексти залежали від базового. Тому тут потрібно вирішити як бути:
1. лишати як є
2. робити базовий контекст з цим методом
3. додавати цей метод в кожний контекст де потрібно
