### PR TITLE
27394: Replace Google Analytics with Google Tag Manager

### DIFF
--- a/app/Resources/views/layout.html.twig
+++ b/app/Resources/views/layout.html.twig
@@ -24,6 +24,17 @@
     </head>
 
     <body>
+        {% if app.environment == 'prod' %}
+            <!-- Google Tag Manager -->
+            <noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-PHVHRX"
+            height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+            <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+            new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+            j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+            '//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+            })(window,document,'script','dataLayer','GTM-PHVHRX');</script>
+            <!-- End Google Tag Manager -->
+        {% endif %}
         <div id="wrapper" class="{% block div_wrapper_class %}no-head{% endblock %}">
 
             <nav class="top-nav">
@@ -105,21 +116,5 @@
         {% block modals %}
             {% render controller('ApplicationDefaultBundle:Default:widgetShareContacts') %}
         {% endblock %}
-
-        {% if app.environment == 'prod' %}
-            <script type="text/javascript">
-
-              var _gaq = _gaq || [];
-              _gaq.push(['_setAccount', 'UA-19310691-2']);
-              _gaq.push(['_trackPageview']);
-
-              (function() {
-                var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-                ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-                var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
-              })();
-
-            </script>
-        {% endif %}
     </body>
 </html>


### PR DESCRIPTION
Replace Google Analytics with Google Tag Manager to be able to manage external JS snippets easier.
